### PR TITLE
Add git submodule for douane-dbus on github

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "dbus/interface"]
+        path = dbus/interface
+        url = https://github.com/Douane/douane-dbus.git
+


### PR DESCRIPTION
This allows douane-dialog to be built, as it requires douane-dbus as a submodule
