### PR TITLE
fix macro collision of dbus and gtkmm

### DIFF
--- a/dbus/dbus_client.h
+++ b/dbus/dbus_client.h
@@ -3,6 +3,7 @@
 
 #include <boost/signals2.hpp>
 #include <log4cxx/logger.h>
+#include <gtkmm.h>
 #include <dbus-c++/dbus.h>
 #include "douane.h"
 #include "../thread.h"

--- a/dbus/douane.h
+++ b/dbus/douane.h
@@ -3,6 +3,7 @@
 
 #include <boost/signals2.hpp>
 #include <log4cxx/logger.h>
+#include <gtkmm.h>
 #include <dbus-c++/dbus.h>
 #include "interface/org_zedroot_douane_proxy.h"
 #include "../network_activity.h"


### PR DESCRIPTION
fix the collision between the macro bind_property in dbus-c++/interface.h and the method bind_property in glibmm/binding.h