### PR TITLE
Update Makefile & Set Question Window Always On Top

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ DAEMON_VERSION=$(shell cat VERSION)
 
 CC=g++
 PKGCONFIG=`pkg-config --cflags --libs liblog4cxx dbus-c++-1 gtkmm-3.0`
-CFLAGS=-pedantic -Wall -W -g $(PKGCONFIG) -DDOUANE_VERSION=\"$(DAEMON_VERSION)\"
+CFLAGS=-pedantic -Wall -W -g $(PKGCONFIG) -DDOUANE_VERSION=\"$(DAEMON_VERSION)\" -std=c++11
 LDFLAGS=$(PKGCONFIG) -lboost_signals -lpthread
 
 OBJ=dbus/dbus_client.o \

--- a/gtk/gtk_question_window.cpp
+++ b/gtk/gtk_question_window.cpp
@@ -13,7 +13,8 @@ GtkQuestionWindow::GtkQuestionWindow(const Glib::RefPtr<Gtk::Application> &appli
 
   // Define Gtk::Window options
   this->set_title("Douane");
-  this->set_resizable(false);
+  this->set_alwaysOnTop(true);
+  this->set_keep_above(true);
   this->set_size_request(600, 200);
   this->set_position(Gtk::WIN_POS_CENTER);
   Tools tools;


### PR DESCRIPTION
libsigc++>=2.5.1 requires "-std=c++11" compiler flag with cmake

Compile fail with

from dbus/dbus_client.cpp:1:
/usr/include/c++/5.5.0/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2011 standard. This support must be enabled with the -std=c++11 or -std=gnu++11 compiler options.

Fix : Adding -std=c++11 to the compiler flags